### PR TITLE
set replication_factor at 1 by default

### DIFF
--- a/conf/garage.toml
+++ b/conf/garage.toml
@@ -4,7 +4,7 @@ data_dir = "__DATA_DIR__/data"
 block_size = 1048576
 block_manager_background_tranquility = 2
 
-replication_mode = "3"
+replication_mode = "1"
 
 compression_level = 1
 


### PR DESCRIPTION
## Problem

App is not functionnal at first because replication is forced at 3

## Solution

Let people choose the to switch to 3 replication after but have a standard install working for "standard" usage

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
