### PR TITLE
upgrade to 2.1.0 and set dummy source to be notified of updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Distributed S3 storage
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://garagehq.deuxfleurs.fr/)
-[![Version: 2.0.0~ynh1](https://img.shields.io/badge/Version-2.0.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/garage/)
+[![Version: 2.1.0~ynh1](https://img.shields.io/badge/Version-2.1.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/garage/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/garage"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -65,6 +65,7 @@ ram.runtime = "50M"
     [resources.sources.binaries] #Actual app binaries used in this package 
     in_subdir = false
     extract = false
+    rename = "garage" #ynh_setup_source() will rename it "binaries" so this is to give it back its original name
     amd64.url = "https://garagehq.deuxfleurs.fr/_releases/v2.1.0/x86_64-unknown-linux-musl/garage"
     amd64.sha256 = "543b0414d1464ab855ebe9b843938a5e5361fd24436891ce3dff9e03d02839d8"
     arm64.url = "https://garagehq.deuxfleurs.fr/_releases/v2.1.0/aarch64-unknown-linux-musl/garage"

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Garage"
 description.en = "Distributed S3 storage"
 description.fr = "Stockage S3 distribué"
 
-version = "1.0.1~ynh1"
+version = "2.1.0~ynh1"
 
 maintainers = [ "oiseauroch" ]
 
@@ -58,19 +58,22 @@ ram.runtime = "50M"
 
 [resources]
 
-    [resources.sources]
+    [resources.sources.main] #Dummy source to get notified of new release by the bot
+    url = "https://git.deuxfleurs.fr/Deuxfleurs/garage/archive/v2.1.0.tar.gz"
+    sha256 = "63b2a0a513464136728bb50a91b40a5911fc25603f3c3e54fe030c01ea5a6084"
+    autoupdate.strategy = "latest_forgejo_release"
 
-    [resources.sources.main]
+    [resources.sources.binaries] #Actual app binaries used in this package 
     in_subdir = false
     extract = false
-    amd64.url = "https://garagehq.deuxfleurs.fr/_releases/v1.0.1/x86_64-unknown-linux-musl/garage"
-    amd64.sha256 = "3444d69063a91a1b4fb771a47f056db53c44f51d51e4eb58fb357fe62fe26f26"
-    arm64.url = "https://garagehq.deuxfleurs.fr/_releases/v1.0.1/aarch64-unknown-linux-musl/garage"
-    arm64.sha256 = "768e3adb246e408c7bd8b9c092f2e3563c28c6c9c63acfb4c7b638eae25bea7a"
-    i386.url = "https://garagehq.deuxfleurs.fr/_releases/v1.0.1/i686-unknown-linux-musl/garage"
-    i386.sha256 = "59f4821a7291b9556f03158dea3cfccbff57f011e654cdf3f164be38ada2a2ce"
-    armhf.url = "https://garagehq.deuxfleurs.fr/_releases/v1.0.1/armv6l-unknown-linux-musleabihf/garage"
-    armhf.sha256 = "13ce750073b887d24ae0eeb4011420c6f78455595622fb7af0e448582a391864"
+    amd64.url = "https://garagehq.deuxfleurs.fr/_releases/v2.1.0/x86_64-unknown-linux-musl/garage"
+    amd64.sha256 = "543b0414d1464ab855ebe9b843938a5e5361fd24436891ce3dff9e03d02839d8"
+    arm64.url = "https://garagehq.deuxfleurs.fr/_releases/v2.1.0/aarch64-unknown-linux-musl/garage"
+    arm64.sha256 = "65a1bedc9b6d5a2df788b55e81cb0013129326478fd94cf83a844ab278e8055f"
+    i386.url = "https://garagehq.deuxfleurs.fr/_releases/v2.1.0/i686-unknown-linux-musl/garage"
+    i386.sha256 = "fff24feca11f613e67a777dc373e9fbd6ce7361b1c1578691c1b92047c5de62c"
+    armhf.url = "https://garagehq.deuxfleurs.fr/_releases/v2.1.0/armv6l-unknown-linux-musleabihf/garage"
+    armhf.sha256 = "4aab47c1d0e6297f6cab61994620dd23cb163a8e21fbb4775e0d029e3c2b85b5"
 
     [resources.ports]
     main.default = 4000

--- a/scripts/install
+++ b/scripts/install
@@ -38,7 +38,6 @@ ynh_app_setting_set --app=$app --key=bootstrap_peers --value=$bootstrap_peers
 ynh_script_progression --message="Setting up source files..." --weight=1
 
 ynh_setup_source --dest_dir="$install_dir" --source_id=binaries
-mv $install_dir/main $install_dir/garage
 
 chmod 750 $install_dir
 chmod +x $install_dir/garage

--- a/scripts/install
+++ b/scripts/install
@@ -37,7 +37,7 @@ ynh_app_setting_set --app=$app --key=bootstrap_peers --value=$bootstrap_peers
 #=================================================
 ynh_script_progression --message="Setting up source files..." --weight=1
 
-ynh_setup_source --dest_dir="$install_dir"
+ynh_setup_source --dest_dir="$install_dir" --source_id=binaries
 mv $install_dir/main $install_dir/garage
 
 chmod 750 $install_dir

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -31,7 +31,7 @@ ynh_systemd_action --service_name=$app --action="stop" --log_path="systemd"
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
-	ynh_setup_source --dest_dir="$install_dir"
+	ynh_setup_source --dest_dir="$install_dir" --source_id=binaries
     mv $install_dir/main $install_dir/garage
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -32,7 +32,6 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
 	ynh_setup_source --dest_dir="$install_dir" --source_id=binaries
-    mv $install_dir/main $install_dir/garage
 fi
 
 chmod 750 $install_dir


### PR DESCRIPTION
Following to meeting one of the upstream dev in a YNH matrix channel who was wondering whether this package could be updated to 2.1.0, here are:
- the links for the new version,
- an added dummy resource (which is the source code attached to forgejo's releases changelog) so that PR are automatically created to this repo notifying about new available versions. Given upstream is not providing the binaries in the release section but on a separate webpage, I think YNH autoupdater cannot currently automatically upgrade the links of the binaries, and this has to be done manually (basically one must change the version number in the URL, and download the assets to compute the new SHA256 sums). 

As I see a lot of work is being done to improve the package through other PRs, maybe this could come on the top on one of these others PR: #49 #43